### PR TITLE
feat(docs): create comprehensive documentation and guidelines

### DIFF
--- a/.cursor/rules/engineering_guidelines.mdc
+++ b/.cursor/rules/engineering_guidelines.mdc
@@ -13,7 +13,7 @@ Every decision, from API design to testing strategy, should be made with these t
 
 ## 2. Go Language & Style
 
-- **Idiomatic Go:** All code must be written in an idiomatic Go style. When in doubt, refer to [Effective Go](https://go.dev/doc/effective_go).
+- **Idiomatic Go:** All code must be written in an idiomatic Go style. When in doubt, refer to [Effective Go](mdc:https:/go.dev/doc/effective_go).
 - **Formatting:** All Go code **must** be formatted with `go fmt` before being committed. This is non-negotiable and will be enforced by our CI pipeline.
 - **Linting:** All code must pass `go vet` and our chosen linter's checks without errors.
 
@@ -75,3 +75,13 @@ We employ a multi-layered testing strategy to ensure correctness and robustness.
 - **GoDoc is Mandatory:** Every single exported function, type, and field in the public API must have a clear and concise GoDoc comment explaining its purpose.
 - **README is the Entrypoint:** The `README.md` must be kept up-to-date with project status, installation instructions, and a quick-start guide.
 - **Examples:** The `examples/` directory should contain working, self-contained examples of how to use the library to solve common tasks.
+
+## 11. Living Documentation
+We treat our documentation as code. It is not an afterthought but a critical part of our development process and a key component of the finished product. Stale or inaccurate documentation is a bug and reflects poorly on the quality of our engineering.
+- **Documentation is Part of the Definition of Done**: A feature is not considered complete until its corresponding documentation is written and updated.
+- **Commit-Coupled Updates**: All documentation related to a code change must be included in the same commit. This ensures that our documentation always reflects the current state of the main branch. This includes, but is not limited to:
+  - The main README.md for high-level feature announcements or usage changes.
+  - The technical documentation in the docs/ directory for architectural or implementation changes.
+  - GoDoc comments for any public API modifications.
+  - The examples/ directory to demonstrate new or changed functionality.
+- **Reviewer Responsibility**: Code reviewers are equally responsible for verifying the quality and completeness of documentation changes. A pull request should not be approved if its documentation is missing, unclear, or inaccurate.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ In a world of hobbyist libraries, ChessNote is engineered for professional use. 
 
 *   **Rock-Solid Reliability:** Built with a strict **Test-Driven Development (TDD)** methodology, ChessNote boasts comprehensive test coverage. Every feature, from simple pawn moves to complex variations, is verified. The parser is designed to handle real-world, messy PGNs without panicking, returning structured errors that make debugging a breeze.
 
-*   **Blazing-Fast Performance:** Written in pure, idiomatic Go, ChessNote is designed for speed. It minimizes allocations and uses an efficient scanning and parsing model to handle large PGN databases with ease. (Benchmarks forthcoming).
+*   **Blazing-Fast Performance:** Written in pure, idiomatic Go, ChessNote is designed for speed. It minimizes allocations and uses an efficient scanning and parsing model to handle large PGN databases with ease. Its performance is validated by a comprehensive benchmark suite (see the `benchmarks/` directory).
 
 *   **A Developer-First API:** The public API is clean, discoverable, and a joy to use. We believe developers should spend their time building great applications, not fighting with a clunky parser. Our data structures (`Game`, `Move`, `Square`) are intuitive and well-documented.
 
@@ -118,6 +118,10 @@ go run .
 ## Project Philosophy
 
 This project adheres to a strict set of engineering guidelines focused on creating professional, enterprise-grade software. We practice **Test-Driven Development (TDD)**, maintain a comprehensive test suite, and prioritize a clean, stable, and well-documented public API.
+
+## Technical Documentation
+
+For a deep dive into the parser's architecture, execution flow, and design decisions, please see our comprehensive **[Technical Documentation](./docs/README.md)**. This is the best resource for developers looking to contribute to the project or understand its inner workings.
 
 ## Roadmap & Contributing
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -97,8 +97,9 @@ The primary goal of this milestone is to elevate the library to a true productio
 
 - **Completed Features**:
     - **Benchmarking**: Added performance benchmarks, including a comprehensive test against a large, real-world PGN file (`Kasparov.pgn`), to validate performance claims and prevent regressions.
-- **Next Step**: Implement a fuzz test for the parser to ensure it handles all malformed input without crashing.
+- **Next Step**: Reorganize and enhance project documentation. This includes creating a detailed technical documentation hub in the `docs/` directory and refining the main `README.md` to serve as a high-level project showcase.
 - **Upcoming Tasks**:
+    - Implement a fuzz test for the parser to ensure it handles all malformed input without crashing.
     - Create a `CONTRIBUTING.md` file to guide future contributors.
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,10 @@
+# ChessNote Technical Documentation
+
+Welcome to the technical documentation for ChessNote. This section provides a deeper dive into the architecture, implementation details, and design decisions behind the library.
+
+It is intended for developers who want to contribute to ChessNote or understand its inner workings. For a general overview and usage instructions, please see the main [README.md](../README.md).
+
+## Table of Contents
+
+- **Parser Architecture**: A detailed explanation of how the PGN parser works, from tokenization to Abstract Syntax Tree (AST) construction. (See [`parser.md`](./parser.md))
+- **Grammar Specification**: The formal EBNF grammar for the PGN format that ChessNote supports. (See [`grammar.ebnf`](./grammar.ebnf)) 

--- a/docs/parser.md
+++ b/docs/parser.md
@@ -1,0 +1,84 @@
+# ChessNote Parser Architecture
+
+This document provides a detailed look into the internal architecture of the ChessNote PGN parser. It is intended for developers who wish to contribute to the library or understand how it reliably transforms PGN text into a structured `Game` object.
+
+## Design Philosophy
+
+The parser is designed around two core principles:
+
+1.  **Scanner/Parser Separation**: Following best practices for compiler design, the process is split into two distinct phases. A `scanner` (or lexer) first converts the raw PGN string into a stream of tokens. A `parser` then consumes this token stream to build the Abstract Syntax Tree (AST), which in our case is the `Game` struct. This separation makes the code cleaner, more modular, and easier to maintain. The scanner is located in the `internal/scanner` package.
+
+2.  **Recursive Descent Parsing**: The parser itself is a handwritten recursive descent parser. This is a natural fit for the PGN format, especially for handling nested structures like Recursive Annotation Variations (RAVs). The parser has a set of mutually recursive functions that mirror the rules of the PGN grammar.
+
+## Execution Flowchart
+
+The following diagram illustrates the high-level execution flow, from the initial user-facing `ParseString` function down to the lower-level parsing routines.
+
+```mermaid
+flowchart TD
+    A["User calls ParseString()"] --> B("NewParser is created")
+    B --> C{"Parse() begins"}
+
+    C --> D{"Loop over top-level elements (tags, moves, result)"}
+    
+    D --> E["<b>Tag Pair '[...]'</b><br>Processed by parseTagPair()"]
+    
+    D --> F["<b>Movetext '1. e4 ...'</b><br>Processed by parseMovetext()"]
+    
+    D --> G["<b>Game Result '1-0'</b><br>The final result is stored"]
+
+    F --> H{"Inner loop for all move elements"}
+    
+    H --> I["<b>Standard Move 'Nf3'</b><br>Deconstructed by<br>parseMove() & parseCoreMove()"]
+    
+    H --> J["<b>RAV '(...)'</b><br>Handled recursively<br>by calling parseMovetext()"]
+    
+    H --> K["<b>NAG '$1'</b><br>Appended to the<br>previous move"]
+
+    style A fill:#333333,stroke:#8ab3d7,stroke-width:2px
+    style G fill:#222222,stroke:#97c495,stroke-width:2px
+```
+
+## Step-by-Step Breakdown
+
+### 1. The Entrypoint: `ParseString`
+
+-   **`ParseString(s string) (*Game, error)`**: This is the main, user-friendly entry point. It takes a raw PGN string, creates a `strings.Reader`, and instantiates a new `Parser` via `NewParser`. It then calls the parser's primary `Parse` method to begin the process.
+
+### 2. The Main Loop: `(*Parser) Parse`
+
+-   **`(*Parser) Parse() (*Game, error)`**: This is the heart of the parser. It initializes a new `Game` struct and enters a loop, consuming tokens from the scanner one by one.
+    -   If it encounters a `[` token, it knows a tag pair is next and calls `parseTagPair`.
+    -   If it encounters a move number (e.g., `1.`) or a move itself (e.g., `e4`), it knows the movetext has begun and calls `parseMovetext`.
+    -   It correctly handles and ignores comments.
+    -   The loop terminates when it sees a game result marker or reaches the end of the file.
+
+### 3. Parsing the Movetext: `parseMovetext` and `parseRAV`
+
+-   **`(*Parser) parseMovetext(*[]Move) error`**: This function is responsible for parsing the sequence of moves in the game. It loops, consuming tokens:
+    -   When it sees a move token (an `IDENT`), it calls `parseMove` to process it.
+    -   When it sees a `(` token, it signifies the start of a variation. It calls `parseRAV`.
+    -   When it sees a Numeric Annotation Glyph (NAG) like `$1`, it appends it to the previously parsed move.
+    -   It ignores move numbers and dots (e.g., `1.`).
+
+-   **`(*Parser) parseRAV(*Move) error`**: To handle nested variations, `parseRAV` is called. It consumes the opening `(` and then **recursively calls `parseMovetext`** to parse the moves within the variation. This elegant recursion allows it to handle arbitrarily deep nested lines. When the inner `parseMovetext` returns, `parseRAV` expects a closing `)` and attaches the parsed variation moves to the parent move.
+
+### 4. Parsing a Single Move: `parseMove` -> `parseCoreMove`
+
+Parsing a single move like `Raxd1#` is a multi-step process of deconstruction.
+
+1.  **`(*Parser) parseMove()`**: This function gets the raw string literal of the move token (e.g., `"Raxd1#"`).
+2.  **`(*Parser) parseMoveFromRaw(raw string)`**: This function strips away suffixes.
+    -   It first looks for a promotion piece (e.g., `=Q`) since a suffix can follow it (`e8=Q#`).
+    -   If there's no promotion, it looks for a check (`+`) or checkmate (`#`) suffix at the very end of the string.
+    -   It handles castling (`O-O`, `O-O-O`) as a special case.
+    -   After stripping these elements, it passes the remaining "core" of the move (e.g., `"Raxd1"`) to the next function.
+3.  **`(*Parser) parseCoreMove(raw string)`**: This function dissects the core move.
+    -   It first identifies the destination square, which is always the last two characters (`d1`).
+    -   It then works backward from the remaining prefix (`Rax`).
+    -   `parsePiece` is called to see if the move starts with a piece identifier (`R`).
+    -   `parseDisambiguation` is called on the rest (`ax`) to determine the starting file or rank (`a`).
+    -   It looks for the capture marker (`x`).
+    -   By the end, the entire string should be consumed. If any characters are left, the move is invalid.
+
+This layered approach breaks down the complexity of SAN (Standard Algebraic Notation) into a series of manageable, testable steps, ensuring robust and accurate parsing. 


### PR DESCRIPTION
This commit introduces a complete overhaul of the project's documentation to align with our new engineering guidelines.

- A new technical documentation hub is created in the /docs directory, featuring a detailed parser architecture breakdown and a visual flowchart.

- The main README.md is updated to serve as a high-level entry point and now links to the detailed technical docs.

- The STATUS.md file is updated to reflect the new documentation-first workflow.